### PR TITLE
fix: mkdirp should be synchronous

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var fs = require('fs')
 var path = require('path')
-var mkdirp = require('mkdirp')
+var mkdirp = require('mkdirp').sync
 var Plugin = require('broccoli-plugin')
 var walkSync = require('walk-sync')
-var pug = require('pug');
-var extend = require('extend');
+var pug = require('pug')
+var extend = require('extend')
 
 function Filter(inputNode, options) {
   this.options = extend({}, options);


### PR DESCRIPTION
According to mkdirp [readme](https://github.com/substack/node-mkdirp/blob/master/readme.markdown), simple `require('mkdirp')` imports asynchronous version of function that should be used with callback. So there should be an import of syncronous version. 
